### PR TITLE
show requester in map card

### DIFF
--- a/client/src/components/modules/MapCard.js
+++ b/client/src/components/modules/MapCard.js
@@ -109,16 +109,30 @@ class MapCard extends Component {
             </a>
           </div>
         ) : (
-          <div className="MapCard-row">
-            Mapset by{" "}
-            <a
-              className="MapCard-link"
-              target="_blank"
-              href={`https://osu.ppy.sh/users/${this.props.creator}`}
-            >
-              {this.props.creator}
-            </a>
-          </div>
+            <>
+              <div className="MapCard-row">
+              Mapset by{" "}
+              <a
+                className="MapCard-link"
+                target="_blank"
+                href={`https://osu.ppy.sh/users/${this.props.creator}`}
+              >
+                {this.props.creator}
+              </a>
+            </div>
+            {this.props.username && this.props.username !== this.props.creator && 
+              <div className="MapCard-row">
+                Requested by{" "}
+                <a
+                  className="MapCard-link"
+                  target="_blank"
+                  href={`https://osu.ppy.sh/users/${this.props.username}`}
+                >
+                  {this.props.username}
+                </a>
+              </div>
+            }
+          </>
         )}
 
         {!this.props.compact && (

--- a/server/api.js
+++ b/server/api.js
@@ -212,6 +212,7 @@ router.postAsync("/request", ensure.loggedIn, async (req, res) => {
       ...map,
       status: "Pending",
       user: req.user.userid,
+      username: req.user.username,
       requestDate: now,
       targetId: req.body.targetId,
       m4m: req.body.m4m || false,

--- a/server/models/request.js
+++ b/server/models/request.js
@@ -2,6 +2,7 @@ const mongoose = require("mongoose");
 
 const RequestSchema = new mongoose.Schema({
   user: Number,
+  username: String,
   requestDate: Date,
   mapId: Number,
   mapsetId: Number,


### PR DESCRIPTION
some dickwads have started spamming other people's maps in queues to get them in trouble with modders, it was suggested in #nat to show requester username so said dickwads can be identified and not get the mappers in unnecessary trouble.

ui portion is a bit hacky because fuck node-osu it's so outdated omfggggggggggggg, i.e. it'll treat a namechange as a different user, better than nothing.

unfortunately this won't work for older reqs because username isn't stored 🙃 